### PR TITLE
fix: Access outer scope .SystemdCgroup

### DIFF
--- a/pkg/agent/templates/templates_linux.go
+++ b/pkg/agent/templates/templates_linux.go
@@ -125,7 +125,7 @@ enable_keychain = true
   runtime_type = "{{$v.RuntimeType}}"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."{{$k}}".options]
   BinaryName = "{{$v.BinaryName}}"
-  SystemdCgroup = {{ .SystemdCgroup }}
+  SystemdCgroup = {{ $.SystemdCgroup }}
 {{end}}
 `
 


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->

<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes ####

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

```
level=fatal msg="template: compiled_template:119:21: executing \"compiled_template\" at <.SystemdCgroup>: can't evaluate field SystemdCgroup in type templates.ContainerdRuntimeConfig
```
When installing k3s with nvidia-container-runtime presented, I hit the error above. It seems the problem was introduced in #8470. Reviewing the code I found that it is referring to an outer scope `.SystemdCgroup` within range loop. 

The change is prepending `$` sign to it.

#### Types of Changes ####

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->
Bugfix

#### Verification ####

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

Start k3s with nvidia-container-runtime presented in system.

#### Testing ####

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

#### User-Facing Change ####
<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed failing to start with nvidia-container-runtime
```

#### Further Comments ####

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
